### PR TITLE
do not fail if all gas has been used

### DIFF
--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -72,9 +72,8 @@ def wait_for_successful_transaction_receipt(web3: Web3, txid: str, timeout=180) 
     :return: Transaction receipt
     """
     receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
-    tx_info = web3.eth.getTransaction(txid)
     status = receipt.get("status", None)
-    if receipt["gasUsed"] == tx_info["gas"] or status is False:
+    if status is False:
         raise TransactionFailed
     return receipt
 


### PR DESCRIPTION
wait_for_successful_transaction_receipt did check if all gas up to the gas limit
had been used and raised an error in that case. The assumption was that a
failing transaction would use up all gas.

We now have the status field inside the transaction receipt and use that to
check if the transaction was successful.

When using infura, we end up with successful transactions that use up all the
gas. These should succeed now.