### PR TITLE
Add workaround for infura's broken getTransactionReceipt

### DIFF
--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -72,6 +72,10 @@ class TransactionFailed(Exception):
 # a block number which is None. This is clearly not what we want. I've copied
 # the following function from web3.utils.transactions and adapted it to also
 # wait for a valid block hash.
+# web3.py from version 5 will already contain this workaround, see
+# https://github.com/ethereum/web3.py/commit/cad343283a1bac3cb8c8cce29a6b09a2e0282fa5
+# (and the parent commit).
+# We should be able to remove our workaround after we upgraded.
 
 
 def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_latency=0.1):

--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -3,6 +3,7 @@ from web3.contract import Contract
 from web3 import Web3
 from web3.eth import Account
 from web3.utils.transactions import fill_nonce
+from web3.utils.threads import Timeout
 
 
 def deploy_compiled_contract(
@@ -67,11 +68,29 @@ class TransactionFailed(Exception):
     pass
 
 
+# When using infura, web3.eth.waitForTransactionReceipt returns a receipt with
+# a block number which is None. This is clearly not what we want. I've copied
+# the following function from web3.utils.transactions and adapted it to also
+# wait for a valid block hash.
+
+
+def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_latency=0.1):
+    with Timeout(timeout) as _timeout:
+        while True:
+            txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+            if txn_receipt is not None and txn_receipt.blockHash is not None:
+                break
+            _timeout.sleep(poll_latency)
+    return txn_receipt
+
+
 def wait_for_successful_transaction_receipt(web3: Web3, txid: str, timeout=180) -> dict:
     """See if transaction went through (Solidity code did not throw).
     :return: Transaction receipt
     """
-    receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
+    # let's call into our patched implementation of
+    # web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
+    receipt = wait_for_transaction_receipt(web3, txid, timeout=timeout)
     status = receipt.get("status", None)
     if status is False:
         raise TransactionFailed


### PR DESCRIPTION
When using infura, web3.eth.waitForTransactionReceipt returns a receipt with a
block number which is None, which probably also means that the transaction
hasn't made it to the chain. This is clearly not what we want.

This commit adds an adapted wait_for_transaction_receipt function, which we use
instead of web3.eth.getTransactionReceipt. It will make sure that we've also
have seen a block hash.

It looks like this may fix
https://github.com/trustlines-protocol/blockchain/issues/70