### PR TITLE
Add cli options to create smaller contracts.json

### DIFF
--- a/deploy_tools/files.py
+++ b/deploy_tools/files.py
@@ -16,8 +16,11 @@ def ensure_path_exists(dir_path):
         os.makedirs(dir_path)
 
 
-def write_compiled_contracts(
-    compiled_contracts: Dict, compiled_contracts_asset_path: str
-):
+def write_pretty_json_asset(json_data: Dict, asset_path: str):
+    with open(asset_path, "w") as file:
+        json.dump(json_data, file, indent=4)
+
+
+def write_minified_json_asset(json_data: Dict, compiled_contracts_asset_path: str):
     with open(compiled_contracts_asset_path, "w") as file:
-        json.dump(compiled_contracts, file, indent=4)
+        json.dump(json_data, file, separators=(",", ":"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,28 @@ def test_default_compile(runner):
 
 
 @pytest.mark.usefixtures("go_to_root_dir")
+def test_minimize_compile(runner):
+    result = runner.invoke(main, "compile -d testcontracts --minimize")
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
+def test_contract_names_compile(runner):
+    result = runner.invoke(
+        main, "compile -d testcontracts --contract-names TestContract"
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
+def test_unknown_contract_names_compile(runner):
+    result = runner.invoke(
+        main, "compile -d testcontracts --contract-names TestContracto"
+    )
+    assert result.exit_code == 2
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
 def test_deploy_simple_contract(runner):
     result = runner.invoke(main, "deploy OtherContract -d testcontracts --jsonrpc test")
     assert result.exit_code == 0


### PR DESCRIPTION
This adds options that can help to make the resulting contract.json
smaller. This was an issue in the clientlib when we realized that the
bundled lib is only so big because of the contract.json

Add minimize option to remove whitespaces
Add only-abi option to only emit the abi
Add contract-names option to only include specific contracts