### PR TITLE
pin the evm target version to byzantium

### DIFF
--- a/deploy_tools/compile.py
+++ b/deploy_tools/compile.py
@@ -87,6 +87,7 @@ def compile_project(
     pattern="*.sol",
     optimize=False,
     only_abi=False,
+    evm_version: str = "byzantium",
 ):
     """
     Compiles all contracts of the project into a single output
@@ -97,6 +98,7 @@ def compile_project(
         pattern: The pattern to find the solidity files
         optimize: Whether to turn on the solidity optimizer
         only_abi: Whether to only create the abi or not
+        evm_version: target evm version to use for generated code
 
     Returns: A dictionary containing the compiled assets of the contracts
 
@@ -125,7 +127,10 @@ def compile_project(
     std_input = {
         "language": "Solidity",
         "sources": sources,
-        "settings": {"outputSelection": {"*": {"*": output_selection}}},
+        "settings": {
+            "outputSelection": {"*": {"*": output_selection}},
+            "evmVersion": evm_version,
+        },
     }
 
     if optimize:


### PR DESCRIPTION
This adds evm_version as an argument to compile.compile_project and uses
"byzantium" as default.

solidity changed the default target version between 0.5.3 and 0.5.7. Our test
infrastructure cannot handle the new version at the moment, so we effectively
pin the version to "byzantium"

We could/should add arguments to specify the target version to the command line
tool later.

This is related to https://github.com/trustlines-protocol/blockchain/issues/83