### PR TITLE
Add option to use already compile contracts for deploy-tool

### DIFF
--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -149,6 +149,10 @@ def compile(
 
     ensure_path_for_file_exists(output)
 
+    if contracts_dir is None:
+        contracts_dir = "contracts"
+    verify_contracts_dir_exists(contracts_dir)
+
     try:
         compiled_contracts = filter_contracts(
             contract_names,
@@ -345,12 +349,16 @@ def get_compiled_contracts(
     else:
         if contracts_dir is None:
             contracts_dir = "contracts"
-        if not Path(contracts_dir).is_dir():
-            raise click.BadOptionUsage(
-                "--contracts-dir", f'Contract directory not found: "{contracts_dir}"'
-            )
+        verify_contracts_dir_exists(contracts_dir)
         return compile_project(
             contracts_dir, optimize=optimize, evm_version=evm_version
+        )
+
+
+def verify_contracts_dir_exists(contracts_dir):
+    if not Path(contracts_dir).is_dir():
+        raise click.BadOptionUsage(
+            "--contracts-dir", f'Contract directory not found: "{contracts_dir}"'
         )
 
 

--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -29,6 +29,8 @@ from .compile import filter_contracts, UnknownContractException, compile_project
 test_provider = EthereumTesterProvider()
 test_json_rpc = Web3(test_provider)
 
+CONTRACTS_DIR_DEFAULT = "contracts"
+
 
 def validate_address(ctx, param, value):
     try:
@@ -74,7 +76,7 @@ auto_nonce_option = click.option(
 contracts_dir_option = click.option(
     "--contracts-dir",
     "-d",
-    help="Directory of the contracts sources",
+    help=f"Directory of the contracts sources [default: {CONTRACTS_DIR_DEFAULT}]",
     type=click.Path(file_okay=False, exists=True),
 )
 optimize_option = click.option(
@@ -150,7 +152,7 @@ def compile(
     ensure_path_for_file_exists(output)
 
     if contracts_dir is None:
-        contracts_dir = "contracts"
+        contracts_dir = CONTRACTS_DIR_DEFAULT
     verify_contracts_dir_exists(contracts_dir)
 
     try:
@@ -348,7 +350,7 @@ def get_compiled_contracts(
         return load_json_asset(compiled_contracts_path)
     else:
         if contracts_dir is None:
-            contracts_dir = "contracts"
+            contracts_dir = CONTRACTS_DIR_DEFAULT
         verify_contracts_dir_exists(contracts_dir)
         return compile_project(
             contracts_dir, optimize=optimize, evm_version=evm_version

--- a/deploy_tools/files.py
+++ b/deploy_tools/files.py
@@ -29,6 +29,11 @@ def write_minified_json_asset(json_data: Dict, compiled_contracts_asset_path: st
         json.dump(json_data, file, separators=(",", ":"))
 
 
+def load_json_asset(asset_path: str):
+    with open(asset_path, "r") as file:
+        return json.load(file)
+
+
 def read_addresses_in_csv(file_path: str):
     with open(file_path) as f:
         reader = csv.reader(f)


### PR DESCRIPTION
closes https://github.com/trustlines-protocol/contract-deploy-tools/issues/43

Still need to fix default value for --contracts-dir and looking at whether the dir exists