### PR TITLE
Add transaction value parameter CLI option

### DIFF
--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -123,6 +123,12 @@ private_key_option = click.option(
     type=str,
     default=None,
 )
+value_option = click.option(
+    "--value",
+    help="Value parameter for a transaction as the amount of Wei to send with",
+    type=int,
+    default=None,
+)
 
 
 @click.group()
@@ -272,6 +278,7 @@ def deploy(
 @contracts_dir_option
 @compiled_contracts_path_option
 @contract_address_option
+@value_option
 def transact(
     contract_name: str,
     function_name: str,
@@ -285,6 +292,7 @@ def transact(
     contracts_dir,
     compiled_contracts_path,
     contract_address,
+    value: int,
 ):
     web3 = connect_to_json_rpc(jsonrpc)
     private_key = retrieve_private_key(keystore)
@@ -293,7 +301,7 @@ def transact(
         web3=web3, nonce=nonce, auto_nonce=auto_nonce, private_key=private_key
     )
     transaction_options = build_transaction_options(
-        gas=gas, gas_price=gas_price, nonce=nonce
+        gas=gas, gas_price=gas_price, nonce=nonce, value=value
     )
 
     compiled_contracts = get_compiled_contracts(

--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Optional
 from pathlib import Path
 from os import path
 
@@ -292,7 +292,7 @@ def transact(
     contracts_dir,
     compiled_contracts_path,
     contract_address,
-    value: int,
+    value: Optional[int],
 ):
     web3 = connect_to_json_rpc(jsonrpc)
     private_key = retrieve_private_key(keystore)

--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -92,7 +92,7 @@ def decrypt_private_key(keystore_path: str, password: str) -> bytes:
     return extract_key_from_keyfile(keystore_path, password.encode("utf-8"))
 
 
-def build_transaction_options(*, gas, gas_price, nonce):
+def build_transaction_options(*, gas, gas_price, nonce, value=None):
 
     transaction_options = {}
 
@@ -102,6 +102,8 @@ def build_transaction_options(*, gas, gas_price, nonce):
         transaction_options["gasPrice"] = gas_price
     if nonce is not None:
         transaction_options["nonce"] = nonce
+    if value is not None:
+        transaction_options["value"] = value
 
     return transaction_options
 

--- a/testcontracts/TestContract.sol
+++ b/testcontracts/TestContract.sol
@@ -14,6 +14,12 @@ contract TestContract {
         state = a;
     }
 
+    function getBalance() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function pay() payable public {}
+
     function testFunction(uint a) public view returns (uint) {
         return a + state;
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,43 @@ def test_send_transaction_to_contract_from_compiled_contracts(
 
 
 @pytest.mark.usefixtures("go_to_root_dir")
+def test_send_transaction_with_value_parameter(
+    runner, test_contract_address, test_contract_name
+):
+    """Change balance of a contract.
+
+    Test the transaction value parameter by a payable function on the
+    test contract. Because of the setup with an internal test RPC
+    endpoint, it is not possible to directly check the contracts
+    balance. Therefore an additional contract function is provided which
+    can be called to retrieve the contracts balance.
+    """
+
+    transaction_value = 1
+    shared_command_string = (
+        f"-d testcontracts --jsonrpc test --contract-address"
+        f" {test_contract_address} -- {test_contract_name}"
+    )
+
+    result_initial_balance_call = runner.invoke(
+        main, f"call {shared_command_string} getBalance"
+    )
+    assert result_initial_balance_call.exit_code == 0
+    assert result_initial_balance_call.output.strip() == "0"
+
+    result_pay_transaction = runner.invoke(
+        main, f"transact --value {transaction_value} {shared_command_string} pay"
+    )
+    assert result_pay_transaction.exit_code == 0
+
+    result_final_balance_call = runner.invoke(
+        main, f"call {shared_command_string} getBalance"
+    )
+    assert result_final_balance_call.exit_code == 0
+    assert result_final_balance_call.output.strip() == f"{transaction_value}"
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
 def test_send_transaction_to_contract_find_duplicated_function_by_argument_length(
     runner, test_contract_address, test_contract_name
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,14 +297,11 @@ def test_send_transaction_to_contract_from_compiled_contracts(
 def test_send_transaction_with_value_parameter(
     runner, test_contract_address, test_contract_name
 ):
-    """Change balance of a contract.
-
-    Test the transaction value parameter by a payable function on the
-    test contract. Because of the setup with an internal test RPC
-    endpoint, it is not possible to directly check the contracts
-    balance. Therefore an additional contract function is provided which
-    can be called to retrieve the contracts balance.
-    """
+    # Change balance of a contract. Test the transaction value parameter by
+    # a payable function on the test contract. Because of the setup with an
+    # internal test RPC endpoint, it is not possible to directly check the
+    # contracts balance. Therefore an additional contract function is provided
+    # which can be called to retrieve the contracts balance.
 
     transaction_value = 1
     shared_command_string = (


### PR DESCRIPTION
Make it possible to define the transaction `value` field with an option for payable functions.
This was triggered by the need for funding the _HomeBridge_ contract.