### PR TITLE
Wait for succesful tx receipt will compare status to int and bool

### DIFF
--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -16,7 +16,7 @@ def deploy_compiled_contract(
     web3: Web3,
     constructor_args=(),
     transaction_options: Dict = None,
-    private_key=None
+    private_key=None,
 ) -> Contract:
     """
     Deploys a compiled contract either using an account of the node, or a local private key
@@ -77,9 +77,14 @@ def wait_for_successful_transaction_receipt(web3: Web3, txid: str, timeout=180) 
     """
     receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
     status = receipt.get("status", None)
-    if status is False:
+    if status == 0:
         raise TransactionFailed
-    return receipt
+    elif status == 1:
+        return receipt
+    else:
+        raise ValueError(
+            f"Unexpected value for status in the transaction receipt: {status}"
+        )
 
 
 def load_contracts_json(package_name, filename="contracts.json") -> Dict:

--- a/testcontracts/TestContract.sol
+++ b/testcontracts/TestContract.sol
@@ -40,4 +40,8 @@ contract TestContract {
         return a;
     }
 
+    function failingFunction() public pure returns (bytes memory) {
+        require(false, "This function can only fail.");
+    }
+
 }

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,7 +2,11 @@ import pytest
 import eth_utils
 from eth_utils import is_address
 
-from deploy_tools.deploy import deploy_compiled_contract, send_function_call_transaction
+from deploy_tools.deploy import (
+    deploy_compiled_contract,
+    send_function_call_transaction,
+    TransactionFailed,
+)
 from deploy_tools.plugin import get_contracts_folder
 from deploy_tools.compile import compile_project
 
@@ -110,6 +114,23 @@ def test_send_contract_call_set_nonce(test_contract, web3, account_keys):
         send_function_call_transaction(
             function_call,
             transaction_options={"nonce": nonce},
+            web3=web3,
+            private_key=account_keys[2],
+        )
+
+
+def test_wait_for_successful_tx_receipt(test_contract, web3, account_keys):
+    """
+    Test that `wait_for_successful_tx_receipt` will catch that this transaction fails and raise an error
+    """
+    function_call = test_contract.functions.failingFunction()
+
+    with pytest.raises(TransactionFailed):
+        # We have to assign gas to make sure eth_tester will not check for transaction success
+        # and leave this job to deploy_tool
+        send_function_call_transaction(
+            function_call,
+            transaction_options={"gas": 123456},
             web3=web3,
             private_key=account_keys[2],
         )


### PR DESCRIPTION
Closes: https://github.com/trustlines-protocol/contract-deploy-tools/issues/61

according to: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt
the returned value should be either 1 or 0. We used to check for true or false.

The test was indeed failing before the fix.

I kept the check for false to potentially avoid introducing a bug.