### PR TITLE
Add click function to get the initcode of a contract

### DIFF
--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -257,7 +257,8 @@ def deploy(
     Deploys a contract
 
     Deploys a contract with the name CONTRACT_NAME and the constructor arguments ARGS.
-
+    If the constructor takes array as arguments, they should be provided without brackets separated by commas.
+    For example int[] could be 123,456,789
     """
     web3 = connect_to_json_rpc(jsonrpc)
     private_key = retrieve_private_key(keystore)
@@ -316,6 +317,8 @@ def initcode(
     as a pre-compiled contract.
 
     Returns the initcode of a contract with the name CONTRACT_NAME and the constructor arguments ARGS.
+    If the constructor takes array as arguments, they should be provided without brackets separated by commas.
+    For example int[] could be 123,456,789
     """
 
     compiled_contracts = get_compiled_contracts(
@@ -373,6 +376,12 @@ def transact(
     contract_address,
     value: Optional[int],
 ):
+    """
+    Send a transaction to a contract CONTRACT_NAME calling function FUNCTION_NAME with arguments ARGS.
+
+    If the function takes array as arguments, they should be provided without brackets separated by commas.
+    For example int[] could be 123,456,789
+    """
     web3 = connect_to_json_rpc(jsonrpc)
     private_key = retrieve_private_key(keystore)
 
@@ -423,6 +432,12 @@ def call(
     contract_address,
     compiled_contracts_path,
 ):
+    """
+    Calls to a contract CONTRACT_NAME calling function FUNCTION_NAME with arguments ARGS.
+
+    If the function takes array as arguments, they should be provided without brackets separated by commas.
+    For example int[] could be 123,456,789
+    """
     web3 = connect_to_json_rpc(jsonrpc)
 
     compiled_contracts = get_compiled_contracts(

--- a/testcontracts/TestContract.sol
+++ b/testcontracts/TestContract.sol
@@ -32,6 +32,9 @@ contract TestContract {
         state = a + b;
     }
 
+    function functionWithArrayArgument(address[] memory a) public {
+    }
+
     function duplicatedSameArgumentLength(uint a) public pure returns (uint) {
         return a;
     }
@@ -43,5 +46,4 @@ contract TestContract {
     function failingFunction() public pure returns (bytes memory) {
         require(false, "This function can only fail.");
     }
-
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,32 @@ def test_deploy_keystore_wrong_nonce(runner, keystore_file_path, key_password):
 
 
 @pytest.mark.usefixtures("go_to_root_dir")
+def test_initcode_simple_contract(runner, key_password):
+    result = runner.invoke(
+        main, f"initcode OtherContract -d testcontracts", input=key_password
+    )
+    assert result.exit_code == 0
+
+    transaction_hash = result.output.splitlines()[-1]
+
+    assert is_hex(transaction_hash)
+    assert is_0x_prefixed(transaction_hash)
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
+def test_initcode_with_constructor_argument(runner, key_password):
+    result = runner.invoke(
+        main, f"initcode TestContract 123456 -d testcontracts", input=key_password
+    )
+    assert result.exit_code == 0
+
+    transaction_hash = result.output.splitlines()[-1]
+
+    assert is_hex(transaction_hash)
+    assert is_0x_prefixed(transaction_hash)
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
 def test_send_transaction_to_contract(
     runner, test_contract_address, test_contract_name
 ):
@@ -325,6 +351,27 @@ def test_send_transaction_with_value_parameter(
     )
     assert result_final_balance_call.exit_code == 0
     assert result_final_balance_call.output.strip() == f"{transaction_value}"
+
+
+@pytest.mark.usefixtures("go_to_root_dir")
+def test_send_transaction_to_contract_with_array_address_arguments(
+    runner, compiled_contracts_path, test_contract_address, test_contract_name
+):
+    argument = f"[{test_contract_address},{test_contract_address}]"
+    result = runner.invoke(
+        main,
+        (
+            f"transact --compiled-contracts {compiled_contracts_path} "
+            f"--jsonrpc test --contract-address {test_contract_address} "
+            f"-- {test_contract_name} functionWithArrayArgument {argument}"
+        ),
+    )
+    assert result.exit_code == 0
+
+    transaction_hash = result.output.splitlines()[-1]
+
+    assert is_hex(transaction_hash)
+    assert is_0x_prefixed(transaction_hash)
 
 
 @pytest.mark.usefixtures("go_to_root_dir")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,9 +255,8 @@ def test_deploy_keystore_wrong_nonce(runner, keystore_file_path, key_password):
 
 @pytest.mark.usefixtures("go_to_root_dir")
 def test_initcode_simple_contract(runner, key_password):
-    result = runner.invoke(
-        main, f"initcode OtherContract -d testcontracts", input=key_password
-    )
+    result = runner.invoke(main, f"initcode OtherContract -d testcontracts")
+    print(result.output)
     assert result.exit_code == 0
 
     transaction_hash = result.output.splitlines()[-1]


### PR DESCRIPTION
This can be used to include the contract as a pre-compile in a chain spec file
Also adds the opportunity to provide an array of address as argument

I did not find a better way to get the initcode than to use a contract object of web3 and build the deployment transaction.

An other way would be to get the bytecode and append the arguments encoded for the constructor.