### PR TITLE
Have the default evm version only in compile_project

### DIFF
--- a/deploy_tools/cli.py
+++ b/deploy_tools/cli.py
@@ -28,6 +28,7 @@ from .compile import (
     UnknownContractException,
     compile_project,
     build_initcode,
+    DEFAULT_EVM_VERSION,
 )
 
 
@@ -116,8 +117,8 @@ evm_version_option = click.option(
     type=str,
     help="The evm target version, one of: "
     "petersburg, constantinople, byzantium, spuriousDragon, tangerineWhistle, or homestead",
+    default=DEFAULT_EVM_VERSION,
     show_default=True,
-    default="petersburg",
     envvar="EVM_VERSION",
 )
 compiled_contracts_path_option = click.option(

--- a/deploy_tools/compile.py
+++ b/deploy_tools/compile.py
@@ -19,6 +19,8 @@ DEFAULT_OUTPUT_SELECTION = [
 
 ABI_OUTPUT_SELECTION = ["abi", "userdoc"]
 
+DEFAULT_EVM_VERSION = "petersburg"
+
 
 def load_sources(file_paths: List[str]):
     result = {}
@@ -89,7 +91,7 @@ def compile_project(
     optimize=True,
     optimize_runs=500,
     only_abi=False,
-    evm_version: str = "petersburg",
+    evm_version: str = DEFAULT_EVM_VERSION,
 ):
     """
     Compiles all contracts of the project into a single output
@@ -104,7 +106,6 @@ def compile_project(
         evm_version: target evm version to use for generated code
 
     Returns: A dictionary containing the compiled assets of the contracts
-
     """
 
     if file_paths is None:

--- a/deploy_tools/plugin.py
+++ b/deploy_tools/plugin.py
@@ -13,6 +13,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 
 
 from deploy_tools import compile_project, deploy_compiled_contract
+from deploy_tools.compile import DEFAULT_EVM_VERSION
 
 
 CONTRACTS_FOLDER_OPTION = "--contracts-dir"
@@ -27,8 +28,12 @@ EVM_VERSION_OPTION_HELP = (
 def pytest_addoption(parser):
     parser.addoption(CONTRACTS_FOLDER_OPTION, help=CONTRACTS_FOLDER_OPTION_HELP)
     parser.addini(CONTRACTS_FOLDER_OPTION, CONTRACTS_FOLDER_OPTION_HELP)
-    parser.addoption(EVM_VERSION_OPTION, help=EVM_VERSION_OPTION_HELP)
-    parser.addini(EVM_VERSION_OPTION, EVM_VERSION_OPTION_HELP)
+    parser.addoption(
+        EVM_VERSION_OPTION, help=EVM_VERSION_OPTION_HELP, default=DEFAULT_EVM_VERSION
+    )
+    parser.addini(
+        EVM_VERSION_OPTION, EVM_VERSION_OPTION_HELP, default=DEFAULT_EVM_VERSION
+    )
 
 
 def get_contracts_folder(pytestconfig):
@@ -38,9 +43,7 @@ def get_contracts_folder(pytestconfig):
 
 
 def get_evm_version(pytestconfig):
-    if pytestconfig.getoption(EVM_VERSION_OPTION, default=None):
-        return pytestconfig.getoption(EVM_VERSION_OPTION)
-    return "byzantium"
+    return pytestconfig.getoption(EVM_VERSION_OPTION)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Have the default evm version only in compile_project for both the cli and the pytest plugin.

The pytests plugin still had default of byzantium because it would not use the default of `compile_project`