### PR TITLE
Set `from` field for local transactions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Change Log
 `unreleased`_
 -------------------------------
 
+`0.6.1`_ (2019-10-14)
+-------------------------------
+* Set the ``from`` address field of a ``eth_sendTransaction`` RPC to the unlocked account of the Ethereum node
+
 `0.6.0`_ (2019-09-26)
 -------------------------------
 * Change default evm target version of cli command ``compile`` to ``petersburg`` to match with the default of ``compile.compile_project`` (BREAKING)
@@ -98,4 +102,5 @@ Change Log
 .. _0.5.2: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.5.1...0.5.2
 .. _0.5.3: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.5.2...0.5.3
 .. _0.6.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.5.3...0.6.0
-.. _unreleased: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.5.1...master
+.. _0.6.1: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.6.0...0.6.1
+.. _unreleased: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.6.1...master

--- a/deploy_tools/deploy.py
+++ b/deploy_tools/deploy.py
@@ -61,7 +61,11 @@ def send_function_call_transaction(
             private_key=private_key,
         )
         tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
+
     else:
+        if "from" not in transaction_options:
+            transaction_options["from"] = web3.eth.accounts[0]
+
         tx_hash = function_call.transact(transaction_options)
 
     return wait_for_successful_transaction_receipt(web3, tx_hash)


### PR DESCRIPTION
See the commit message for a detailed explanation.
This does fix the problems which have occurred during the upgrade of the `tl-deploy` tool.

@cducrest as far as I know this problem has not raised so far, because the test plugin [is setting the `web3.eth.defaultAccount`](https://github.com/trustlines-protocol/contract-deploy-tools/blob/c84e2f5c101cc52efe679109b6f50f753c9f105d/deploy_tools/plugin.py#L121) and in practice we have always used it with `--keystore`. Maybe you could verify that this is true?

After merging, this should release a new version and gets integrated to the other repositories.