### PR TITLE
Prefer web3.eth.defaultAccount for signing transactions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@
 Change Log
 ==========
 
-`unreleased`_
+`0.7.1`_ (2020-01-24)
 -------------------------------
+* Prefer web3.eth.defaultAccount for signing transactions
+
 `0.7.0`_ (2019-11-04)
 -------------------------------
 * Add a send eth command to send eth on the command line
@@ -107,4 +109,4 @@ Change Log
 .. _0.6.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.5.3...0.6.0
 .. _0.6.1: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.6.0...0.6.1
 .. _0.7.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.6.1...0.7.0
-.. _unreleased: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.0...master
+.. _0.7.1: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.0...0.7.1

--- a/src/deploy_tools/deploy.py
+++ b/src/deploy_tools/deploy.py
@@ -39,6 +39,16 @@ def deploy_compiled_contract(
     return contract(address)
 
 
+def _set_from_address(web3, transaction_options):
+    """set the from address in the transaction options
+
+    transact() will not fill the from field by asking the node
+    we need to do that ourselves
+    """
+    if "from" not in transaction_options:
+        transaction_options["from"] = web3.eth.defaultAccount or web3.eth.accounts[0]
+
+
 def send_function_call_transaction(
     function_call, *, web3: Web3, transaction_options: Dict = None, private_key=None
 ):
@@ -62,10 +72,7 @@ def send_function_call_transaction(
         tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
 
     else:
-        # transact() will not fill the from field by asking the node
-        # we need to ask it ourselves with web3.eth.accounts[0]
-        if "from" not in transaction_options:
-            transaction_options["from"] = web3.eth.accounts[0]
+        _set_from_address(web3, transaction_options)
 
         tx_hash = function_call.transact(transaction_options)
 
@@ -99,11 +106,7 @@ def send_transaction(*, web3: Web3, transaction_options: Dict, private_key=None)
         tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
 
     else:
-        # web3.eth.sendTransaction() will not fill the from field by asking the node
-        # we need to ask it ourselves with web3.eth.accounts[0]
-        if "from" not in transaction_options:
-            transaction_options["from"] = web3.eth.accounts[0]
-
+        _set_from_address(web3, transaction_options)
         tx_hash = web3.eth.sendTransaction(transaction_options)
 
     receipt = wait_for_successful_transaction_receipt(web3, tx_hash)


### PR DESCRIPTION
When setting the 'from' address for signing transactions, we did use
web3.eth.accounts[0] as default from address if no 'from' address had
been given.

With this commit, we will prefer web3.eth.defaultAccount if it's set.

This will allow us to run the relay server with a node, that doesn't
have an unlocked account or even has no account at all.

It would probably have been better to explicitly require the 'from'
address, but at the moment I don't want to make that change.