### PR TITLE
Require web3<5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "py-solc",
-        "web3>=5.0.0b2",
+        "web3>=5.0.0,<5.2",
         "eth-tester[py-evm]",
         "eth-utils",
         "eth-keyfile",


### PR DESCRIPTION
Starting with web3 5.2.0 we run into the following error:
```
,----
| _____________________________ test_initcode_with_constructor_argument _____________________________
| tests/test_cli.py:273: in test_initcode_with_constructor_argument
|     assert result.exit_code == 0
| E   assert 1 == 0
| E    +  where 1 = <Result AttributeError("'NoneType' object has no attribute 'codec'")>.exit_code
| ______________________________ test_build_initcode_with_constructor _______________________________
| tests/test_compile.py:17: in test_build_initcode_with_constructor
|     constructor_args=[123456],
| ../../venv/lib64/python3.7/site-packages/deploy_tools/compile.py:183: in build_initcode
|     data=contract_bytecode,
| ../../venv/lib64/python3.7/site-packages/web3/_utils/contracts.py:129: in encode_abi
|     if not check_if_arguments_can_be_encoded(abi, web3.codec, arguments, {}):
| E   AttributeError: 'NoneType' object has no attribute 'codec'
`----
```