### PR TITLE
Add option --expose-rpc=port to expose the rpc of the test chain.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     eth-utils
     eth-keyfile
     click
+    eth-tester-rpc
 
 [options.entry_points]
 console_scripts =
@@ -56,7 +57,7 @@ ignore =
        E203
 
 [tool:pytest]
-addopts = --contracts-dir testcontracts
+addopts = --contracts-dir testcontracts --expose-rpc=8545
 
 [isort]
 line_length=88

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,3 +8,22 @@ def contract(deploy_contract):
 
 def test_call(contract):
     assert contract.functions.testFunction(3).call() == 7
+
+
+def test_chain_web3_synchrone(web3, chain):
+    """Test that the chain fixture and web3 are connected to the same chain"""
+    # Uses `chain` to mine a block and verify that web3 observes a new block
+    block_number_before = web3.eth.blockNumber
+    chain.mine_block()
+    block_number_after = web3.eth.blockNumber
+    assert block_number_after - block_number_before == 1
+
+
+def test_chain_snapshot(web3, chain):
+    """Test that reverting a snapshot via the `chain` fixture will affect the chain connected via web3"""
+    block_number_before = web3.eth.blockNumber
+    snapshot = chain.take_snapshot()
+    chain.mine_block()
+    chain.revert_to_snapshot(snapshot)
+    block_number_after = web3.eth.blockNumber
+    assert block_number_after == block_number_before


### PR DESCRIPTION
Exposes the web3 rpc on localhost:port if used.