### PR TITLE
Move transaction related functions from deploy to transact

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 ==========
 Change Log
 ==========
+`0.9.0`_ (2020-01-13)
+-------------------------------
+* Changed: Move transaction sending related functions from `deploy.py` to `transact.py`:
+  `send_function_call_transaction`, `send_transaction`, `build_transaction_options`,
+  `increase_transaction_options_nonce`, and `wait_for_successful_transaction_receipt`.
+* Changed: Repurposed `send_function_call_transaction` to no longer wait for the success of the sent transaction
+* Added: `wait_for_successful_function_call` that sends a function call and wait for its success
+* Changed: Repurposed `send_transaction` to no longer wait for the success of the sent transaction
+* Added: `wait_for_successful_transaction` that sends a transaction and wait for its success
+* Added: `wait_for_successful_transaction_receipts` to wait for a list of transaction ids to be successful
 
 `0.8.0`_ (2020-10-08)
 -------------------------------
@@ -121,3 +131,4 @@ Change Log
 .. _0.7.1: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.0...0.7.1
 .. _0.7.2: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.1...0.7.2
 .. _0.8.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.2...0.8.0
+.. _0.9.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.8.0...0.9.0

--- a/src/deploy_tools/cli.py
+++ b/src/deploy_tools/cli.py
@@ -16,13 +16,7 @@ from .compile import (
     compile_project,
     filter_contracts,
 )
-from .deploy import (
-    build_transaction_options,
-    decrypt_private_key,
-    deploy_compiled_contract,
-    send_function_call_transaction,
-    send_transaction,
-)
+from .deploy import decrypt_private_key, deploy_compiled_contract
 from .files import (
     InvalidAddressException,
     ensure_path_for_file_exists,
@@ -30,6 +24,11 @@ from .files import (
     validate_and_format_address,
     write_minified_json_asset,
     write_pretty_json_asset,
+)
+from .transact import (
+    build_transaction_options,
+    wait_for_successful_function_call,
+    wait_for_successful_transaction,
 )
 
 # we need test_provider and test_json_rpc for running the tests in test_cli
@@ -137,7 +136,7 @@ contract_address_option = click.option(
 )
 keystore_file_save_option = click.option(
     "--keystore-path",
-    help=f"Path where to store the keystore file",
+    help="Path where to store the keystore file",
     type=click.Path(resolve_path=True),
     default=KEYSTORE_FILE_SAVE_DEFAULT,
     show_default=True,
@@ -405,7 +404,7 @@ def transact(
     parsed_arguments = parse_args_to_matching_types_for_function(args, function_abi)
     function_call = contract.functions[function_name](*parsed_arguments)
 
-    receipt = send_function_call_transaction(
+    receipt = wait_for_successful_function_call(
         function_call,
         web3=web3,
         transaction_options=transaction_options,
@@ -521,7 +520,7 @@ def send_eth(
 
     transaction_options["to"] = address
 
-    receipt = send_transaction(
+    receipt = wait_for_successful_transaction(
         web3=web3, transaction_options=transaction_options, private_key=private_key
     )
 
@@ -538,7 +537,7 @@ def get_compiled_contracts(
     if contracts_dir is not None and compiled_contracts_path is not None:
         raise click.BadOptionUsage(
             "--contracts-dir, --compiled-contracts",
-            f"Both --contracts-dir and --compiled-contracts were specified. Please only use one of the two.",
+            "Both --contracts-dir and --compiled-contracts were specified. Please only use one of the two.",
         )
     if compiled_contracts_path is not None:
         return load_json_asset(compiled_contracts_path)

--- a/src/deploy_tools/deploy.py
+++ b/src/deploy_tools/deploy.py
@@ -3,12 +3,10 @@ from typing import Dict
 
 import pkg_resources
 from eth_keyfile import extract_key_from_keyfile
-from hexbytes import HexBytes
 from web3 import Web3
-from web3._utils.transactions import fill_nonce, fill_transaction_defaults
 from web3.contract import Contract
-from web3.eth import Account
-from web3.types import TxParams, TxReceipt
+
+from deploy_tools.transact import wait_for_successful_function_call
 
 
 def deploy_compiled_contract(
@@ -30,7 +28,7 @@ def deploy_compiled_contract(
     contract = web3.eth.contract(abi=abi, bytecode=bytecode)
     constuctor_call = contract.constructor(*constructor_args)
 
-    receipt = send_function_call_transaction(
+    receipt = wait_for_successful_function_call(
         constuctor_call,
         web3=web3,
         transaction_options=transaction_options,
@@ -41,103 +39,6 @@ def deploy_compiled_contract(
     return contract(address)
 
 
-def _set_from_address(web3, transaction_options):
-    """set the from address in the transaction options
-
-    transact() will not fill the from field by asking the node
-    we need to do that ourselves
-    """
-    if "from" not in transaction_options:
-        transaction_options["from"] = web3.eth.defaultAccount or web3.eth.accounts[0]
-
-
-def send_function_call_transaction(
-    function_call, *, web3: Web3, transaction_options: Dict = None, private_key=None
-):
-    """
-    Creates, signs and sends a transaction from a function call (for example created with `contract.functions.foo()`.
-    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
-    It will block until the transaction was successfully mined.
-
-    Returns: The transaction receipt
-    """
-    if transaction_options is None:
-        transaction_options = {}
-
-    if private_key is not None:
-        signed_transaction = _build_and_sign_transaction(
-            function_call,
-            web3=web3,
-            transaction_options=transaction_options,
-            private_key=private_key,
-        )
-        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
-
-    else:
-        _set_from_address(web3, transaction_options)
-
-        tx_hash = function_call.transact(transaction_options)
-
-    return wait_for_successful_transaction_receipt(web3, tx_hash)
-
-
-def send_transaction(*, web3: Web3, transaction_options: TxParams, private_key=None):
-    """
-    Send the transaction with given transaction options
-    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
-    It will block until the transaction was successfully mined.
-
-    Returns: The transaction receipt
-    """
-
-    if private_key is not None:
-        account = Account.from_key(private_key)
-
-        if (
-            "from" in transaction_options
-            and transaction_options["from"] != account.address
-        ):
-            raise ValueError(
-                "From can not be set in transaction_options if a private key is used"
-            )
-        transaction_options["from"] = account.address
-
-        transaction = fill_nonce(web3, transaction_options)
-        transaction = fill_transaction_defaults(web3, transaction)
-        signed_transaction = account.sign_transaction(transaction)
-        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
-
-    else:
-        _set_from_address(web3, transaction_options)
-        tx_hash = web3.eth.sendTransaction(transaction_options)
-
-    receipt = wait_for_successful_transaction_receipt(web3, tx_hash)
-
-    return receipt
-
-
-class TransactionFailed(Exception):
-    pass
-
-
-def wait_for_successful_transaction_receipt(
-    web3: Web3, txid: HexBytes, timeout=180
-) -> TxReceipt:
-    """See if transaction went through (Solidity code did not throw).
-    :return: Transaction receipt
-    """
-    receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
-    status = receipt.get("status", None)
-    if status == 0:
-        raise TransactionFailed
-    elif status == 1:
-        return receipt
-    else:
-        raise ValueError(
-            f"Unexpected value for status in the transaction receipt: {status}"
-        )
-
-
 def load_contracts_json(package_name, filename="contracts.json") -> Dict:
     resource_package = package_name
     json_string = pkg_resources.resource_string(resource_package, filename)
@@ -146,43 +47,3 @@ def load_contracts_json(package_name, filename="contracts.json") -> Dict:
 
 def decrypt_private_key(keystore_path: str, password: str) -> bytes:
     return extract_key_from_keyfile(keystore_path, password.encode("utf-8"))
-
-
-def build_transaction_options(*, gas, gas_price, nonce, value=None):
-
-    transaction_options = {}
-
-    if gas is not None:
-        transaction_options["gas"] = gas
-    if gas_price is not None:
-        transaction_options["gasPrice"] = gas_price
-    if nonce is not None:
-        transaction_options["nonce"] = nonce
-    if value is not None:
-        transaction_options["value"] = value
-
-    return transaction_options
-
-
-def increase_transaction_options_nonce(transaction_options: Dict) -> None:
-    """Increases the nonce inside of `transaction_options` by 1 if present.
-    If there is no nonce in `transaction_options`, this function will not do anything
-    """
-    if "nonce" in transaction_options:
-        transaction_options["nonce"] = transaction_options["nonce"] + 1
-
-
-def _build_and_sign_transaction(
-    function_call, *, web3, transaction_options, private_key
-):
-    account = Account.from_key(private_key)
-
-    if "from" in transaction_options and transaction_options["from"] != account.address:
-        raise ValueError(
-            "From can not be set in transaction_options if a private key is used"
-        )
-    transaction_options["from"] = account.address
-
-    transaction = fill_nonce(web3, function_call.buildTransaction(transaction_options))
-
-    return account.sign_transaction(transaction)

--- a/src/deploy_tools/transact.py
+++ b/src/deploy_tools/transact.py
@@ -1,0 +1,213 @@
+from typing import Dict, Iterable
+
+from hexbytes import HexBytes
+from web3 import Web3
+from web3._utils.transactions import fill_transaction_defaults
+from web3.eth import Account
+from web3.types import TxParams, TxReceipt
+
+
+class TransactionsFailed(Exception):
+    def __init__(self, failed_tx_hashs):
+        self.failed_tx_hashs = failed_tx_hashs
+
+
+class TransactionFailed(Exception):
+    pass
+
+
+def send_transaction(*, web3: Web3, transaction_options: TxParams, private_key=None):
+    """
+    Send the transaction with given transaction options
+    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
+    It will not block until the transaction was successfully mined.
+
+    Returns: The sent transaction hash
+    """
+
+    if private_key is not None:
+        account = Account.from_key(private_key)
+
+        if (
+            "from" in transaction_options
+            and transaction_options["from"] != account.address
+        ):
+            raise ValueError(
+                "From can not be set in transaction_options if a private key is used"
+            )
+        transaction_options["from"] = account.address
+
+        transaction = fill_nonce(web3, transaction_options)
+        transaction = fill_transaction_defaults(web3, transaction)
+        signed_transaction = account.sign_transaction(transaction)
+        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
+
+    else:
+        _set_from_address(web3, transaction_options)
+        tx_hash = web3.eth.sendTransaction(transaction_options)
+
+    return tx_hash
+
+
+def wait_for_successful_transaction(
+    *, web3: Web3, transaction_options: TxParams, private_key=None
+):
+    """
+    Send the transaction with given transaction options
+    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
+    It will block until the transaction was successfully mined.
+
+    Returns: The transaction receipt
+    """
+
+    tx_hash = send_transaction(
+        web3=web3, transaction_options=transaction_options, private_key=private_key
+    )
+    return wait_for_successful_transaction_receipt(web3=web3, txid=tx_hash)
+
+
+def send_function_call_transaction(
+    function_call, *, web3: Web3, transaction_options: Dict = None, private_key=None
+):
+    """
+    Creates, signs and sends a transaction from a function call (for example created with `contract.functions.foo()`.
+    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
+    It will not block until tx is sent
+
+    Returns: The transaction hash
+    """
+    if transaction_options is None:
+        transaction_options = {}
+
+    if private_key is not None:
+        signed_transaction = _build_and_sign_transaction(
+            function_call,
+            web3=web3,
+            transaction_options=transaction_options,
+            private_key=private_key,
+        )
+        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
+
+    else:
+        _set_from_address(web3, transaction_options)
+        fill_nonce(web3, transaction_options)
+        tx_hash = function_call.transact(transaction_options)
+
+    return tx_hash
+
+
+def wait_for_successful_function_call(
+    function_call, *, web3: Web3, transaction_options: Dict = None, private_key=None
+):
+    """
+    Creates, signs and sends a transaction from a function call (for example created with `contract.functions.foo()`.
+    Will either use an account of the node(default), or a local private key(if given) to sign the transaction.
+    It will block until the transaction was successfully mined.
+
+    Returns: The transaction receipt
+    """
+    tx_hash = send_function_call_transaction(
+        function_call,
+        web3=web3,
+        transaction_options=transaction_options,
+        private_key=private_key,
+    )
+    return wait_for_successful_transaction_receipt(web3, tx_hash)
+
+
+def wait_for_successful_transaction_receipts(
+    web3, tx_hashs: Iterable[HexBytes], timeout=300
+):
+
+    failed_tx_hashs = set()
+
+    for tx_hash in tx_hashs:
+        receipt = web3.eth.waitForTransactionReceipt(tx_hash, timeout=timeout)
+        status = receipt.get("status", None)
+        if status == 0:
+            failed_tx_hashs.add(tx_hash)
+        elif status == 1:
+            continue
+        else:
+            raise ValueError(
+                f"Unexpected value for status in the transaction receipt: {status}"
+            )
+
+    if len(failed_tx_hashs) != 0:
+        raise TransactionsFailed(failed_tx_hashs)
+
+
+def wait_for_successful_transaction_receipt(
+    web3: Web3, txid: HexBytes, timeout=180
+) -> TxReceipt:
+    """See if transaction went through (Solidity code did not throw).
+    :return: Transaction receipt
+    """
+    receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
+    status = receipt.get("status", None)
+    if status == 0:
+        raise TransactionFailed
+    elif status == 1:
+        return receipt
+    else:
+        raise ValueError(
+            f"Unexpected value for status in the transaction receipt: {status}"
+        )
+
+
+def _build_and_sign_transaction(
+    function_call, *, web3, transaction_options, private_key
+):
+    account = Account.from_key(private_key)
+
+    if "from" in transaction_options and transaction_options["from"] != account.address:
+        raise ValueError(
+            "From can not be set in transaction_options if a private key is used"
+        )
+    transaction_options["from"] = account.address
+
+    transaction = fill_nonce(web3, function_call.buildTransaction(transaction_options))
+
+    return account.sign_transaction(transaction)
+
+
+def build_transaction_options(*, gas, gas_price, nonce, value=None):
+
+    transaction_options = {}
+
+    if gas is not None:
+        transaction_options["gas"] = gas
+    if gas_price is not None:
+        transaction_options["gasPrice"] = gas_price
+    if nonce is not None:
+        transaction_options["nonce"] = nonce
+    if value is not None:
+        transaction_options["value"] = value
+
+    return transaction_options
+
+
+def fill_nonce(web3, transaction_options):
+    if "from" in transaction_options and "nonce" not in transaction_options:
+        transaction_options["nonce"] = web3.eth.getTransactionCount(
+            transaction_options["from"], block_identifier="pending"
+        )
+    return transaction_options
+
+
+def _set_from_address(web3, transaction_options):
+    """set the from address in the transaction options
+
+    transact() will not fill the from field by asking the node
+    we need to do that ourselves
+    """
+    if "from" not in transaction_options:
+        transaction_options["from"] = web3.eth.defaultAccount or web3.eth.accounts[0]
+
+
+def increase_transaction_options_nonce(transaction_options: Dict) -> None:
+    """Increases the nonce inside of `transaction_options` by 1 if present.
+    If there is no nonce in `transaction_options`, this function will not do anything
+    """
+    if "nonce" in transaction_options:
+        transaction_options["nonce"] = transaction_options["nonce"] + 1

--- a/testcontracts/ManyArgumentsContract.sol
+++ b/testcontracts/ManyArgumentsContract.sol
@@ -17,5 +17,4 @@ contract ManyArgumentsContract {
         e = _e;
         f = _f;
     }
-
 }

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,20 +1,9 @@
-import eth_utils
 import pytest
 from eth_utils import is_address
 
 from deploy_tools.compile import compile_project
-from deploy_tools.deploy import (
-    TransactionFailed,
-    deploy_compiled_contract,
-    send_function_call_transaction,
-    send_transaction,
-)
+from deploy_tools.deploy import deploy_compiled_contract
 from deploy_tools.plugin import get_contracts_folder
-
-
-@pytest.fixture()
-def test_contract(deploy_contract):
-    return deploy_contract("TestContract", constructor_args=(4,))
 
 
 @pytest.fixture()
@@ -61,96 +50,3 @@ def test_deploy_st_petersburg(web3, contract_assets_st_petersburg):
     )
 
     assert is_address(contract.address)
-
-
-def test_send_contract_call(test_contract, web3):
-
-    function_call = test_contract.functions.set(200)
-
-    receipt = send_function_call_transaction(function_call, web3=web3)
-
-    assert receipt["status"]
-    assert test_contract.functions.state().call() == 200
-
-
-def test_send_contract_call_from_private_key(test_contract, web3, account_keys):
-
-    function_call = test_contract.functions.set(200)
-
-    receipt = send_function_call_transaction(
-        function_call, web3=web3, private_key=account_keys[2]
-    )
-
-    assert receipt["status"]
-    assert test_contract.functions.state().call() == 200
-
-
-def test_send_contract_call_with_transaction_options(test_contract, web3, account_keys):
-
-    function_call = test_contract.functions.set(200)
-
-    transaction_options = {"gas": 199999, "gasPrice": 99}
-
-    receipt = send_function_call_transaction(
-        function_call,
-        web3=web3,
-        transaction_options=transaction_options,
-        private_key=account_keys[2],
-    )
-
-    transaction = web3.eth.getTransaction(receipt.transactionHash)
-
-    for key, value in transaction_options.items():
-        assert transaction[key] == value
-
-
-def test_send_contract_call_set_nonce(test_contract, web3, account_keys):
-
-    function_call = test_contract.functions.set(200)
-    nonce = 1  # right nonce should be 0
-
-    # This should just test, that the nonce is set
-    # Apparently eth_tester raises a validation error if the nonce to high
-    with pytest.raises(eth_utils.ValidationError):
-        send_function_call_transaction(
-            function_call,
-            transaction_options={"nonce": nonce},
-            web3=web3,
-            private_key=account_keys[2],
-        )
-
-
-def test_wait_for_successful_tx_receipt(test_contract, web3, account_keys):
-    """
-    Test that `wait_for_successful_tx_receipt` will catch that this transaction fails and raise an error
-    """
-    function_call = test_contract.functions.failingFunction()
-
-    with pytest.raises(TransactionFailed):
-        # We have to assign gas to make sure eth_tester will not check for transaction success
-        # and leave this job to deploy_tool
-        send_function_call_transaction(
-            function_call,
-            transaction_options={"gas": 123456},
-            web3=web3,
-            private_key=account_keys[2],
-        )
-
-
-@pytest.mark.parametrize("use_private_key", [True, False])
-def test_send_eth_default_account(web3, accounts, account_keys, use_private_key):
-    pre_balance_0 = web3.eth.getBalance(accounts[0])
-    pre_balance_1 = web3.eth.getBalance(accounts[1])
-    value = 123
-    transaction_option = {"value": value, "to": accounts[1], "gasPrice": 0}
-    send_transaction(
-        web3=web3,
-        transaction_options=transaction_option,
-        private_key=account_keys[0] if use_private_key else None,
-    )
-
-    post_balance_0 = web3.eth.getBalance(accounts[0])
-    post_balance_1 = web3.eth.getBalance(accounts[1])
-
-    assert post_balance_0 - pre_balance_0 == -value
-    assert post_balance_1 - pre_balance_1 == value

--- a/tests/test_transact.py
+++ b/tests/test_transact.py
@@ -1,0 +1,106 @@
+import eth_utils
+import pytest
+
+from deploy_tools.transact import (
+    TransactionFailed,
+    wait_for_successful_function_call,
+    wait_for_successful_transaction,
+)
+
+
+@pytest.fixture()
+def test_contract(deploy_contract):
+    return deploy_contract("TestContract", constructor_args=(4,))
+
+
+def test_send_contract_call(test_contract, web3):
+
+    function_call = test_contract.functions.set(200)
+
+    receipt = wait_for_successful_function_call(function_call, web3=web3)
+
+    assert receipt["status"]
+    assert test_contract.functions.state().call() == 200
+
+
+def test_send_contract_call_from_private_key(test_contract, web3, account_keys):
+
+    function_call = test_contract.functions.set(200)
+
+    receipt = wait_for_successful_function_call(
+        function_call, web3=web3, private_key=account_keys[2]
+    )
+
+    assert receipt["status"]
+    assert test_contract.functions.state().call() == 200
+
+
+def test_send_contract_call_with_transaction_options(test_contract, web3, account_keys):
+
+    function_call = test_contract.functions.set(200)
+
+    transaction_options = {"gas": 199999, "gasPrice": 99}
+
+    receipt = wait_for_successful_function_call(
+        function_call,
+        web3=web3,
+        transaction_options=transaction_options,
+        private_key=account_keys[2],
+    )
+
+    transaction = web3.eth.getTransaction(receipt.transactionHash)
+
+    for key, value in transaction_options.items():
+        assert transaction[key] == value
+
+
+def test_send_contract_call_set_nonce(test_contract, web3, account_keys):
+
+    function_call = test_contract.functions.set(200)
+    nonce = 1  # right nonce should be 0
+
+    # This should just test, that the nonce is set
+    # Apparently eth_tester raises a validation error if the nonce to high
+    with pytest.raises(eth_utils.ValidationError):
+        wait_for_successful_function_call(
+            function_call,
+            transaction_options={"nonce": nonce},
+            web3=web3,
+            private_key=account_keys[2],
+        )
+
+
+def test_wait_for_successful_tx_receipt(test_contract, web3, account_keys):
+    """
+    Test that `wait_for_successful_tx_receipt` will catch that this transaction fails and raise an error
+    """
+    function_call = test_contract.functions.failingFunction()
+
+    with pytest.raises(TransactionFailed):
+        # We have to assign gas to make sure eth_tester will not check for transaction success
+        # and leave this job to deploy_tool
+        wait_for_successful_function_call(
+            function_call,
+            transaction_options={"gas": 123456},
+            web3=web3,
+            private_key=account_keys[2],
+        )
+
+
+@pytest.mark.parametrize("use_private_key", [True, False])
+def test_send_eth_default_account(web3, accounts, account_keys, use_private_key):
+    pre_balance_0 = web3.eth.getBalance(accounts[0])
+    pre_balance_1 = web3.eth.getBalance(accounts[1])
+    value = 123
+    transaction_option = {"value": value, "to": accounts[1], "gasPrice": 0}
+    wait_for_successful_transaction(
+        web3=web3,
+        transaction_options=transaction_option,
+        private_key=account_keys[0] if use_private_key else None,
+    )
+
+    post_balance_0 = web3.eth.getBalance(accounts[0])
+    post_balance_1 = web3.eth.getBalance(accounts[1])
+
+    assert post_balance_0 - pre_balance_0 == -value
+    assert post_balance_1 - pre_balance_1 == value


### PR DESCRIPTION
Split functions that send and wait for a transaction to a function
that sends the transaction and does not wait and one that waits.