### PR TITLE
Change default kdf used for generating keystore to pbkdf2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ==========
 Change Log
 ==========
+`unreleased`_
+-------------------------------
+* Updated: default key derivation function (kdf) for generate_keystore changed to `pbkdf2` to be compatible with
+  OpenEthereum. Use option `--kdf` to use custom kdf.
+
 `0.9.1`_ (2020-01-26)
 -------------------------------
 * Updated: No longer fill nonce for user when no private key is used, leave that task to the blockchain node.
@@ -138,3 +143,4 @@ Change Log
 .. _0.8.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.7.2...0.8.0
 .. _0.9.0: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.8.0...0.9.0
 .. _0.9.1: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.9.0...0.9.1
+.. _unreleased: https://github.com/trustlines-protocol/contract-deploy-tools/compare/0.9.1...master

--- a/src/deploy_tools/cli.py
+++ b/src/deploy_tools/cli.py
@@ -459,8 +459,19 @@ def call(
     short_help="Generates an encrypted keystore file. Creates a new account if no private key is provided."
 )
 @keystore_file_save_option
+@click.option(
+    "--kdf",
+    "key_derivation_function",
+    help="Key derivation function to be used for the keystore. "
+    "As of OpenEthereum 3.1, only pbkdf2 seems to be supported.",
+    type=str,
+    default="pbkdf2",
+    show_default=True,
+)
 @private_key_option
-def generate_keystore(keystore_path: str, private_key: str):
+def generate_keystore(
+    keystore_path: str, private_key: str, key_derivation_function: str
+):
     if path.exists(keystore_path):
         raise click.BadOptionUsage(  # type: ignore
             "--keystore-file", f"The file {keystore_path} does already exist!"
@@ -477,7 +488,7 @@ def generate_keystore(keystore_path: str, private_key: str):
         hide_input=True,
         confirmation_prompt=True,
     )
-    keystore = account.encrypt(password=password)
+    keystore = account.encrypt(password=password, kdf=key_derivation_function)
 
     with open(keystore_path, "w") as file:
         file.write(json.dumps(keystore))


### PR DESCRIPTION
Add option --kdf to use custom kdf to generate keystore.
This was necessary because the default used by eth_account changed
to scrypt which seems not to work with OE 3.1