### PR TITLE
Feature/get revert reason

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,12 +4,17 @@
 #
 #    pip-compile --output-file=dev-requirements.txt dev-requirements.in setup.py
 #
+aiohttp==3.7.4.post0
+    # via web3
 appdirs==1.4.3
     # via
     #   black
     #   virtualenv
+async-timeout==3.0.1
+    # via aiohttp
 attrs==19.3.0
     # via
+    #   aiohttp
     #   black
     #   jsonschema
     #   pytest
@@ -28,7 +33,9 @@ certifi==2019.11.28
 cfgv==3.1.0
     # via pre-commit
 chardet==3.0.4
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==7.1.1
     # via
     #   black
@@ -117,8 +124,10 @@ hexbytes==0.2.0
 identify==1.4.13
     # via pre-commit
 idna==2.9
-    # via requests
-ipfshttpclient==0.4.12
+    # via
+    #   requests
+    #   yarl
+ipfshttpclient==0.7.0
     # via web3
 json-rpc==1.13.0
     # via eth-tester-rpc
@@ -134,6 +143,10 @@ more-itertools==8.2.0
     # via pytest
 multiaddr==0.0.9
     # via ipfshttpclient
+multidict==5.1.0
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==0.4.3
     # via
     #   mypy
@@ -214,7 +227,6 @@ setuptools-scm==3.5.0
     # via -r dev-requirements.in
 six==1.14.0
     # via
-    #   ipfshttpclient
     #   jsonschema
     #   multiaddr
     #   packaging
@@ -242,6 +254,7 @@ typed-ast==1.4.1
     #   mypy
 typing-extensions==3.7.4.1
     # via
+    #   aiohttp
     #   mypy
     #   trie
 urllib3==1.25.8
@@ -254,7 +267,7 @@ virtualenv==20.0.13
     #   tox
 wcwidth==0.1.9
     # via pytest
-web3==5.9.0
+web3==5.20.0
     # via contract-deploy-tools (setup.py)
 websockets==8.1
     # via web3
@@ -262,6 +275,8 @@ werkzeug==1.0.1
     # via eth-tester-rpc
 wheel==0.34.2
     # via -r dev-requirements.in
+yarl==1.6.3
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages=find:
 
 install_requires =
     py-solc
-    web3>=5.4.0,<6.0.0
+    web3>=5.13.0,<6.0.0
     eth-tester[py-evm]
     eth-utils
     eth-keyfile

--- a/src/deploy_tools/cli.py
+++ b/src/deploy_tools/cli.py
@@ -585,11 +585,11 @@ def get_nonce(*, web3: Web3, nonce: int, private_key: bytes):
     if nonce is not None:
         return nonce
     elif private_key is not None:
-        return web3.eth.getTransactionCount(
+        return web3.eth.get_transaction_count(
             Account.from_key(private_key).address, block_identifier="pending"
         )
     else:
-        return web3.eth.getTransactionCount(
+        return web3.eth.get_transaction_count(
             web3.eth.accounts[0], block_identifier="pending"
         )
 

--- a/src/deploy_tools/transact.py
+++ b/src/deploy_tools/transact.py
@@ -40,7 +40,7 @@ def send_transaction(*, web3: Web3, transaction_options: TxParams, private_key=N
         transaction = fill_nonce(web3, transaction_options)
         transaction = fill_transaction_defaults(web3, transaction)
         signed_transaction = account.sign_transaction(transaction)
-        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
+        tx_hash = web3.eth.send_raw_transaction(signed_transaction.rawTransaction)
 
     else:
         _set_from_address(web3, transaction_options)
@@ -86,7 +86,7 @@ def send_function_call_transaction(
             transaction_options=transaction_options,
             private_key=private_key,
         )
-        tx_hash = web3.eth.sendRawTransaction(signed_transaction.rawTransaction)
+        tx_hash = web3.eth.send_raw_transaction(signed_transaction.rawTransaction)
 
     else:
         _set_from_address(web3, transaction_options)
@@ -122,7 +122,7 @@ def wait_for_successful_transaction_receipts(
     failed_tx_hashs = set()
 
     for tx_hash in tx_hashs:
-        receipt = web3.eth.waitForTransactionReceipt(tx_hash, timeout=timeout)
+        receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=timeout)
         status = receipt.get("status", None)
         if status == 0:
             failed_tx_hashs.add(tx_hash)
@@ -143,7 +143,7 @@ def wait_for_successful_transaction_receipt(
     """See if transaction went through (Solidity code did not throw).
     :return: Transaction receipt
     """
-    receipt = web3.eth.waitForTransactionReceipt(txid, timeout=timeout)
+    receipt = web3.eth.wait_for_transaction_receipt(txid, timeout=timeout)
     status = receipt.get("status", None)
     if status == 0:
         raise TransactionFailed
@@ -189,7 +189,7 @@ def build_transaction_options(*, gas, gas_price, nonce, value=None):
 
 def fill_nonce(web3, transaction_options):
     if "from" in transaction_options and "nonce" not in transaction_options:
-        transaction_options["nonce"] = web3.eth.getTransactionCount(
+        transaction_options["nonce"] = web3.eth.get_transaction_count(
             transaction_options["from"], block_identifier="pending"
         )
     return transaction_options


### PR DESCRIPTION
I was failing to transact with a contract and the "TransactionFailure" exception was not particularly helpful. 

It turns out that the latest web3 version has the ability to output the revert reason so, we are now trying to get it before raising a "TransactionFailure" exception.